### PR TITLE
typescript fix

### DIFF
--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,4 +1,4 @@
 import { ButtonHTMLAttributes } from 'react';
 
-export type ButtonType = any;
+export type ButtonType = "button" | "submit" | "reset";
 export type ButtonVariant = 'primary' | 'secondary';

--- a/src/ui/components/Form/Form.tsx
+++ b/src/ui/components/Form/Form.tsx
@@ -1,23 +1,26 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent } from "react";
 
-import Button from '../Button/Button';
-import InputText from '../InputText/InputText';
-import $ from './Form.module.css';
+import Button from "../Button/Button";
+import InputText from "../InputText/InputText";
+import $ from "./Form.module.css";
+
+import { ButtonType } from "@/types";
 
 interface FormEntry {
   name: string;
   placeholder: string;
   // TODO: Defined a suitable type for extra props
   // This type should cover all different of attribute types
-  extraProps: any;
+  extraProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 interface FormProps {
   label: string;
   loading: boolean;
   formEntries: FormEntry[];
-  onFormSubmit: () => void;
+  onFormSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   submitText: string;
+  submitType?: ButtonType;
 }
 
 const Form: FunctionComponent<FormProps> = ({
@@ -25,7 +28,8 @@ const Form: FunctionComponent<FormProps> = ({
   loading,
   formEntries,
   onFormSubmit,
-  submitText
+  submitText,
+  submitType = "submit",
 }) => {
   return (
     <form onSubmit={onFormSubmit}>
@@ -42,7 +46,7 @@ const Form: FunctionComponent<FormProps> = ({
           </div>
         ))}
 
-        <Button loading={loading} type="submit">
+        <Button loading={loading} type={submitType}>
           {submitText}
         </Button>
       </fieldset>


### PR DESCRIPTION
- [v ] Refactor the `extraProps` in `<Form />` component. Use a proper type to cover all the different form property types.
- [v ] Defined a typescript type for the button type inside `src/types/button`. This type should only include all the possible types for a button.
